### PR TITLE
Fix backend 500 server error

### DIFF
--- a/backend/.venv/pyvenv.cfg
+++ b/backend/.venv/pyvenv.cfg
@@ -1,5 +1,5 @@
-home = C:\Users\phili\AppData\Local\Programs\Python\Python313
+home = /usr/bin
 include-system-site-packages = false
-version = 3.13.5
-executable = C:\Users\phili\AppData\Local\Programs\Python\Python313\python.exe
-command = C:\Users\phili\AppData\Local\Programs\Python\Python313\python.exe -m venv C:\Users\phili\.cursor\gedenken\backend\.venv
+version = 3.13.3
+executable = /usr/bin/python3.13
+command = /usr/bin/python3 -m venv /workspace/backend/.venv

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -4,9 +4,9 @@
 set -e
 
 # Erstellt das media-Verzeichnis, falls es nicht existiert.
-# Das ist wichtig, da Render den Mount-Pfad, aber nicht den Unterordner erstellt.
+# Wichtig: In Produktion ist das Volume unter /var/media gemountet, MEDIA_ROOT ist /var/media/media
 echo "Creating media directory if it doesn't exist..."
-mkdir -p /app/media
+mkdir -p /var/media/media
 
 # Führt die Datenbank-Migrationen aus
 echo "Applying database migrations..."
@@ -30,6 +30,7 @@ EOF
 
 # Startet den Gunicorn Webserver, damit die Anwendung online ist
 echo "Starting Gunicorn server..."
-# ÄNDERUNG: Der Port wird jetzt auf 8000 gesetzt, um Konsistenz zu wahren
-gunicorn core.wsgi:application --bind 0.0.0.0:8000
+# Bindet an den von Render bereitgestellten PORT (Fallback 8000 für lokale Nutzung)
+PORT=${PORT:-8000}
+gunicorn core.wsgi:application --bind 0.0.0.0:$PORT
 

--- a/render.yaml
+++ b/render.yaml
@@ -26,6 +26,8 @@ services:
         fromDatabase:
           name: vorsorge-db
           property: connectionString
+      - key: DJANGO_ENV
+        value: production
       - key: SECRET_KEY
         generateValue: true
       - key: DJANGO_SETTINGS_MODULE


### PR DESCRIPTION
Configure Render deployment settings for Gunicorn, media files, and Django environment to resolve backend 500 server errors.

The 500 errors were likely caused by Gunicorn not binding to Render's assigned port, an incorrect media directory path preventing file operations, and production settings not being applied, leading to various runtime exceptions. These changes ensure the application runs correctly in a production environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-67fc3234-e130-441c-9d41-af06a32d1248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67fc3234-e130-441c-9d41-af06a32d1248">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

